### PR TITLE
Make hast-to-dom composable with other DOM tools - compose DOM with a…

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,7 @@ import html from 'property-information/html';
 import svg from 'property-information/svg';
 
 function transform(node, options) {
+  if (node.nodeType) return node;
   switch (node.type) {
     case 'root':
       return root(node, options);

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -293,6 +293,27 @@ describe('hast-util-to-dom', () => {
     expect(actual).toEqual('<html><title>FOO</title><h2>BAR</h2></html>');
   });
 
+  it('should support nested Nodes', () => {
+    const child = toDOM(
+      {
+        type: 'element',
+        tagName: 'h1',
+        properties: { className: 'child-class' },
+        children: [{ type: 'text', value: 'World!' }],
+      },
+    );
+    const parent = toDOM(
+      {
+        type: 'element',
+        tagName: 'div',
+        properties: { className: 'parent-class' },
+        children: [child, { type: 'text', value: 'And Beyond!' }],
+      },
+    );
+    const actual = serializeNodeToHtmlString(parent);
+    expect(actual).toEqual('<div class="parent-class"><h1 class="child-class">World!</h1>And Beyond!</div>');
+  });
+
   describe('booleanish property', () => {
     it('handles booleanish attribute with `true` value correctly', () => {
       const actual = serializeNodeToHtmlString(toDOM(h('div', {


### PR DESCRIPTION
…lready generated dom fragments

This is minor change (1 line) but allows
- to compose hast with other DOM tools (apart from hastscript)
- to build custom DOM elements on top of hast that can then be mixed into another hast element

I needed this change for my code to work and if it doesn't conflicts with any parts of hast ecosystem please feel free to merge.
