### PR TITLE
Add support for `afterTransform` hook

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -12,12 +12,14 @@
  * @property {boolean} [fragment=false] Whether a DOM fragment should be returned
  * @property {Document} [document] Document interface to use (default: `globalThis.document`)
  * @property {string} [namespace] `namespace` to use to create elements
+ * @property {(node: HastNode, transformed: Node) => void} [afterTransform] Callback invoked after each node transformation
  *
  * @typedef Context
  * @property {Document} doc
  * @property {boolean} [fragment=false]
  * @property {string} [namespace]
  * @property {string} [impliedNamespace]
+ * @property {Options['afterTransform']} [afterTransform]
  */
 
 import {webNamespaces} from 'web-namespaces'
@@ -30,19 +32,28 @@ import {find, html, svg} from 'property-information'
  * @param {Context} ctx
  */
 function transform(node, ctx) {
-  switch (node.type) {
-    case 'root':
-      return root(node, ctx)
-    case 'text':
-      return text(node, ctx)
-    case 'element':
-      return element(node, ctx)
-    case 'doctype':
-      return doctype(node, ctx)
-    case 'comment':
-      return comment(node, ctx)
-    default:
-      return element(node, ctx)
+  const transformed = transformer(node)
+  ctx.afterTransform?.(node, transformed)
+  return transformed
+
+  /**
+   * @param {HastNode} node
+   */
+  function transformer(node) {
+    switch (node.type) {
+      case 'root':
+        return root(node, ctx)
+      case 'text':
+        return text(node, ctx)
+      case 'element':
+        return element(node, ctx)
+      case 'doctype':
+        return doctype(node, ctx)
+      case 'comment':
+        return comment(node, ctx)
+      default:
+        return element(node, ctx)
+    }
   }
 }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -33,7 +33,7 @@ import {find, html, svg} from 'property-information'
  */
 function transform(node, ctx) {
   const transformed = transformer(node)
-  ctx.afterTransform?.(node, transformed)
+  if (ctx.afterTransform) ctx.afterTransform(node, transformed)
   return transformed
 
   /**

--- a/lib/index.js
+++ b/lib/index.js
@@ -8,18 +8,30 @@
  * @typedef {HastParent['children'][number]} HastChild
  * @typedef {HastChild|HastRoot} HastNode
  *
+ * @callback AfterTransform
+ *   Function called when a hast node is transformed into a DOM node
+ * @param {HastNode} hastNode
+ *   The hast node that was handled
+ * @param {Node} domNode
+ *   The corresponding DOM node
+ * @returns {void}
+ *
  * @typedef Options
- * @property {boolean} [fragment=false] Whether a DOM fragment should be returned
- * @property {Document} [document] Document interface to use (default: `globalThis.document`)
- * @property {string} [namespace] `namespace` to use to create elements
- * @property {(node: HastNode, transformed: Node) => void} [afterTransform] Callback invoked after each node transformation
+ * @property {boolean} [fragment=false]
+ *   Whether a DOM fragment should be returned
+ * @property {Document} [document]
+ *   Document interface to use (default: `globalThis.document`)
+ * @property {string} [namespace]
+ *   `namespace` to use to create elements
+ * @property {AfterTransform} [afterTransform]
+ *   Callback invoked after each node transformation
  *
  * @typedef Context
  * @property {Document} doc
  * @property {boolean} [fragment=false]
  * @property {string} [namespace]
  * @property {string} [impliedNamespace]
- * @property {Options['afterTransform']} [afterTransform]
+ * @property {AfterTransform} [afterTransform]
  */
 
 import {webNamespaces} from 'web-namespaces'
@@ -32,28 +44,29 @@ import {find, html, svg} from 'property-information'
  * @param {Context} ctx
  */
 function transform(node, ctx) {
-  const transformed = transformer(node)
+  const transformed = one(node, ctx)
   if (ctx.afterTransform) ctx.afterTransform(node, transformed)
   return transformed
+}
 
-  /**
-   * @param {HastNode} node
-   */
-  function transformer(node) {
-    switch (node.type) {
-      case 'root':
-        return root(node, ctx)
-      case 'text':
-        return text(node, ctx)
-      case 'element':
-        return element(node, ctx)
-      case 'doctype':
-        return doctype(node, ctx)
-      case 'comment':
-        return comment(node, ctx)
-      default:
-        return element(node, ctx)
-    }
+/**
+ * @param {HastNode} node
+ * @param {Context} ctx
+ */
+function one(node, ctx) {
+  switch (node.type) {
+    case 'root':
+      return root(node, ctx)
+    case 'text':
+      return text(node, ctx)
+    case 'element':
+      return element(node, ctx)
+    case 'doctype':
+      return doctype(node, ctx)
+    case 'comment':
+      return comment(node, ctx)
+    default:
+      return element(node, ctx)
   }
 }
 

--- a/readme.md
+++ b/readme.md
@@ -88,6 +88,10 @@ Document interface to use (default: `globalThis.document`).
 
 `namespace` to use to create [*elements*][element].
 
+###### `options.afterTransform(node, transformed)`
+
+Callback invoked after each node transformation (`Function`).
+
 ## Security
 
 Use of `hast-util-to-dom` can open you up to a

--- a/readme.md
+++ b/readme.md
@@ -88,9 +88,11 @@ Document interface to use (default: `globalThis.document`).
 
 `namespace` to use to create [*elements*][element].
 
-###### `options.afterTransform(node, transformed)`
+###### `options.afterTransform`
 
-Callback invoked after each node transformation (`Function`).
+Function called when a hast node is transformed into a DOM node (`Function?`).
+Given the hast node that was handled as the first parameter and the
+corresponding DOM node as the second parameter.
 
 ## Security
 

--- a/test/index.js
+++ b/test/index.js
@@ -359,6 +359,25 @@ test('hast-util-to-dom', (t) => {
     'encodes data properties when string'
   )
 
+  t.deepEqual(
+    (() => {
+      /** @type {Array<[HastNode, string]>} */
+      const calls = []
+      toDom(h('html', [h('title', 'Hi')]), {
+        afterTransform: (node, transformed) => {
+          calls.push([node, serializeNodeToHtmlString(transformed)])
+        }
+      })
+      return calls
+    })(),
+    [
+      [{type: 'text', value: 'Hi'}, 'Hi'],
+      [h('title', 'Hi'), '<title>Hi</title>'],
+      [h('html', [h('title', 'Hi')]), '<html><title>Hi</title></html>']
+    ],
+    'should invoke afterTransform'
+  )
+
   t.end()
 })
 


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/syntax-tree/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/syntax-tree/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/syntax-tree/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Asyntax-tree&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

Closes #14

<!--do not edit: pr-->