### PR TITLE
feat!: Align namespace-switching logic to the HTML living standard tree construction rules

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -227,64 +227,6 @@ function comment(node, state) {
 }
 
 /**
- * Choose element and child namespaces based on integration points and overrides.
- *
- * @param {string} tagName
- *   Current node's tag name
- * @param {string|undefined} current
- *   Implied namespace
- * @param {HastProperties} properties
- *   Node properties
- * @returns {{self: string|undefined, child: string|undefined}}
- *   Namespaces of element and child
- */
-function chooseNamespaces(tagName, current, properties) {
-  // Explicit xmlns override on the current element
-  if (properties.xmlns) {
-    const override = String(properties.xmlns)
-    return {self: override, child: override}
-  }
-
-  // Switch automatically from HTML on embedded content.
-  if (current === undefined || current === webNamespaces.html) {
-    if (tagName === 'svg') {
-      return {
-        self: webNamespaces.svg,
-        child: webNamespaces.svg
-      }
-    }
-
-    if (tagName === 'math') {
-      return {
-        self: webNamespaces.mathml,
-        child: webNamespaces.mathml
-      }
-    }
-  }
-
-  // Switch automatically to HTML on integration points
-  // https://html.spec.whatwg.org/multipage/parsing.html#html-integration-point
-  const encoding = String(properties.encoding || '').toLowerCase()
-  if (
-    (current === webNamespaces.svg &&
-      ['foreignObject', 'desc', 'title'].includes(tagName)) ||
-    (current === webNamespaces.mathml &&
-      tagName === 'annotation-xml' &&
-      (encoding === 'text/html' || encoding === 'application/xhtml+xml'))
-  ) {
-    return {
-      self: current,
-      child: webNamespaces.html
-    }
-  }
-
-  return {
-    self: current,
-    child: current
-  }
-}
-
-/**
  * Create an `element`.
  *
  * @param {HastElement} node
@@ -399,5 +341,63 @@ function appendAll(node, children, state) {
 
   while (++index < children.length) {
     node.append(transform(children[index], state))
+  }
+}
+
+/**
+ * Choose element and child namespaces based on integration points and overrides.
+ *
+ * @param {string} tagName
+ *   Current node's tag name
+ * @param {string|undefined} current
+ *   Implied namespace
+ * @param {HastProperties} properties
+ *   Node properties
+ * @returns {{self: string|undefined, child: string|undefined}}
+ *   Namespaces of element and child
+ */
+function chooseNamespaces(tagName, current, properties) {
+  // Explicit xmlns override on the current element
+  if (properties.xmlns) {
+    const override = String(properties.xmlns)
+    return {self: override, child: override}
+  }
+
+  // Switch automatically from HTML on embedded content.
+  if (current === undefined || current === webNamespaces.html) {
+    if (tagName === 'svg') {
+      return {
+        self: webNamespaces.svg,
+        child: webNamespaces.svg
+      }
+    }
+
+    if (tagName === 'math') {
+      return {
+        self: webNamespaces.mathml,
+        child: webNamespaces.mathml
+      }
+    }
+  }
+
+  // Switch automatically to HTML on integration points
+  // https://html.spec.whatwg.org/multipage/parsing.html#html-integration-point
+  const encoding = String(properties.encoding || '').toLowerCase()
+  if (
+    (current === webNamespaces.svg &&
+      ['foreignObject', 'desc', 'title'].includes(tagName)) ||
+    (current === webNamespaces.mathml &&
+      tagName === 'annotation-xml' &&
+      (encoding === 'text/html' || encoding === 'application/xhtml+xml'))
+  ) {
+    return {
+      self: current,
+      child: webNamespaces.html
+    }
+  }
+
+  return {
+    self: current,
+    child: current
   }
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -229,6 +229,86 @@ function comment(node, state) {
 }
 
 /**
+ * Choose a namespace-aware tag name.
+ *
+ * @param {HastElement} node
+ *   Current node
+ * @param {string|undefined} namespace
+ *   Implied namespace
+ * @returns {string}
+ *   Tag name
+ */
+function chooseTagName(node, namespace) {
+  if (node.tagName) return node.tagName
+
+  if (namespace === webNamespaces.svg) return 'g'
+  if (namespace === webNamespaces.mathml) return 'mrow'
+
+  return 'div'
+}
+
+/**
+ * Choose element and child namespaces based on integration points and overrides.
+ *
+ * @param {string} tagName
+ *   Current node's tag name
+ * @param {string|undefined} currentNamespace
+ *   Implied namespace
+ * @param {HastProperties} properties
+ *   Node properties
+ * @returns {{elementNamespace: string|undefined, childNamespace: string|undefined}}
+ *   Namespaces of element and child
+ */
+function chooseNamespaces(tagName, currentNamespace, properties) {
+  // Explicit xmlns override on the current element
+  if (properties.xmlns) {
+    const override = String(properties.xmlns)
+    return {elementNamespace: override, childNamespace: override}
+  }
+
+  // Switch automatically from HTML on embedded content.
+  if (
+    currentNamespace === undefined ||
+    currentNamespace === webNamespaces.html
+  ) {
+    if (tagName === 'svg') {
+      return {
+        elementNamespace: webNamespaces.svg,
+        childNamespace: webNamespaces.svg
+      }
+    }
+
+    if (tagName === 'math') {
+      return {
+        elementNamespace: webNamespaces.mathml,
+        childNamespace: webNamespaces.mathml
+      }
+    }
+  }
+
+  // Switch automatically to HTML on integration points
+  // https://html.spec.whatwg.org/multipage/parsing.html#html-integration-point
+  const encoding = String(properties.encoding || '').toLowerCase()
+  if (
+    (currentNamespace === webNamespaces.svg &&
+      ['foreignObject', 'desc', 'title'].includes(tagName)) ||
+    (currentNamespace === webNamespaces.mathml &&
+      tagName === 'annotation-xml' &&
+      (encoding === 'text/html' || encoding === 'application/xhtml+xml'))
+  ) {
+    return {
+      elementNamespace: currentNamespace,
+      childNamespace: webNamespaces.html
+    }
+  }
+
+  return {
+    elementNamespace: currentNamespace,
+    childNamespace: currentNamespace
+  }
+}
+
+/**
  * Create an `element`.
  *
  * @param {HastElement} node
@@ -239,35 +319,33 @@ function comment(node, state) {
  *   DOM element.
  */
 function element(node, state) {
-  let impliedNamespace = state.impliedNamespace || state.namespace
+  const currentNamespace = state.impliedNamespace || state.namespace
+
   // Important: unknown nodes are passed to `element`.
-  const tagName =
-    node.tagName || (impliedNamespace === webNamespaces.svg ? 'g' : 'div')
+  const tagName = chooseTagName(node, currentNamespace)
+
   const properties = node.properties || {}
   const children = node.children || []
 
-  // Switch automatically from HTML to SVG on `<svg>`.
-  if (
-    (impliedNamespace === undefined ||
-      impliedNamespace === webNamespaces.html) &&
-    tagName === 'svg'
-  ) {
-    impliedNamespace = webNamespaces.svg
-  }
+  const {elementNamespace, childNamespace} = chooseNamespaces(
+    tagName,
+    currentNamespace,
+    properties
+  )
 
-  const result = impliedNamespace
-    ? state.doc.createElementNS(impliedNamespace, tagName)
+  const result = elementNamespace
+    ? state.doc.createElementNS(elementNamespace, tagName)
     : state.doc.createElement(tagName)
 
   addProperties(
     result,
     properties,
-    impliedNamespace === webNamespaces.svg ? svg : html
+    elementNamespace === webNamespaces.svg ? svg : html
   )
 
   appendAll(result, children, {
     ...state,
-    impliedNamespace: impliedNamespace
+    impliedNamespace: childNamespace
   })
 
   return result

--- a/lib/index.js
+++ b/lib/index.js
@@ -227,25 +227,6 @@ function comment(node, state) {
 }
 
 /**
- * Choose a namespace-aware tag name.
- *
- * @param {HastElement} node
- *   Current node
- * @param {string|undefined} namespace
- *   Implied namespace
- * @returns {string}
- *   Tag name
- */
-function chooseTagName(node, namespace) {
-  if (node.tagName) return node.tagName
-
-  if (namespace === webNamespaces.svg) return 'g'
-  if (namespace === webNamespaces.mathml) return 'mrow'
-
-  return 'div'
-}
-
-/**
  * Choose element and child namespaces based on integration points and overrides.
  *
  * @param {string} tagName
@@ -320,7 +301,13 @@ function element(node, state) {
   const currentNamespace = state.impliedNamespace || state.namespace
 
   // Important: unknown nodes are passed to `element`.
-  const tagName = chooseTagName(node, currentNamespace)
+  const tagName =
+    node.tagName ||
+    (currentNamespace === webNamespaces.svg
+      ? 'g'
+      : currentNamespace === webNamespaces.mathml
+        ? 'mrow'
+        : 'div')
 
   const properties = node.properties || {}
   const children = node.children || []

--- a/lib/index.js
+++ b/lib/index.js
@@ -265,10 +265,10 @@ function element(node, state) {
     impliedNamespace === webNamespaces.svg ? svg : html
   )
 
-  const currentImpliedNamespace = state.impliedNamespace
-  state.impliedNamespace = impliedNamespace
-  appendAll(result, children, state)
-  state.impliedNamespace = currentImpliedNamespace
+  appendAll(result, children, {
+    ...state,
+    impliedNamespace: impliedNamespace
+  })
 
   return result
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -231,36 +231,33 @@ function comment(node, state) {
  *
  * @param {string} tagName
  *   Current node's tag name
- * @param {string|undefined} currentNamespace
+ * @param {string|undefined} current
  *   Implied namespace
  * @param {HastProperties} properties
  *   Node properties
- * @returns {{elementNamespace: string|undefined, childNamespace: string|undefined}}
+ * @returns {{self: string|undefined, child: string|undefined}}
  *   Namespaces of element and child
  */
-function chooseNamespaces(tagName, currentNamespace, properties) {
+function chooseNamespaces(tagName, current, properties) {
   // Explicit xmlns override on the current element
   if (properties.xmlns) {
     const override = String(properties.xmlns)
-    return {elementNamespace: override, childNamespace: override}
+    return {self: override, child: override}
   }
 
   // Switch automatically from HTML on embedded content.
-  if (
-    currentNamespace === undefined ||
-    currentNamespace === webNamespaces.html
-  ) {
+  if (current === undefined || current === webNamespaces.html) {
     if (tagName === 'svg') {
       return {
-        elementNamespace: webNamespaces.svg,
-        childNamespace: webNamespaces.svg
+        self: webNamespaces.svg,
+        child: webNamespaces.svg
       }
     }
 
     if (tagName === 'math') {
       return {
-        elementNamespace: webNamespaces.mathml,
-        childNamespace: webNamespaces.mathml
+        self: webNamespaces.mathml,
+        child: webNamespaces.mathml
       }
     }
   }
@@ -269,21 +266,21 @@ function chooseNamespaces(tagName, currentNamespace, properties) {
   // https://html.spec.whatwg.org/multipage/parsing.html#html-integration-point
   const encoding = String(properties.encoding || '').toLowerCase()
   if (
-    (currentNamespace === webNamespaces.svg &&
+    (current === webNamespaces.svg &&
       ['foreignObject', 'desc', 'title'].includes(tagName)) ||
-    (currentNamespace === webNamespaces.mathml &&
+    (current === webNamespaces.mathml &&
       tagName === 'annotation-xml' &&
       (encoding === 'text/html' || encoding === 'application/xhtml+xml'))
   ) {
     return {
-      elementNamespace: currentNamespace,
-      childNamespace: webNamespaces.html
+      self: current,
+      child: webNamespaces.html
     }
   }
 
   return {
-    elementNamespace: currentNamespace,
-    childNamespace: currentNamespace
+    self: current,
+    child: current
   }
 }
 
@@ -312,7 +309,7 @@ function element(node, state) {
   const properties = node.properties || {}
   const children = node.children || []
 
-  const {elementNamespace, childNamespace} = chooseNamespaces(
+  const {self: elementNamespace, child: childNamespace} = chooseNamespaces(
     tagName,
     currentNamespace,
     properties

--- a/test/index.js
+++ b/test/index.js
@@ -536,4 +536,9 @@ function serializeNodeToHtmlString(node) {
   return serialized
     .replace(new RegExp(` xmlns="${webNamespaces.html}"`, 'g'), '')
     .replace(new RegExp(`(<(?:g|svg)) xmlns="${webNamespaces.svg}"`, 'g'), '$1')
+    .replace(
+      new RegExp(`(<(?:math|mrow)) xmlns="${webNamespaces.mathml}"`, 'g'),
+      '$1'
+    )
+    .replace(/<(mglyph|malignmark|mspace)\/>/g, '<$1></$1>')
 }

--- a/test/index.js
+++ b/test/index.js
@@ -166,53 +166,47 @@ test('toDom', async function (t) {
   await t.test(
     'should create SVG `foreignObject` children with HTML namespace',
     async function () {
-      const {calls, document: instrumentedDocument} =
-        createInstrumentedDocument()
+      const tree = toDom({
+        type: 'element',
+        tagName: 'svg',
+        properties: {},
+        children: [
+          {
+            type: 'element',
+            tagName: 'foreignObject',
+            properties: {},
+            children: [
+              {
+                type: 'element',
+                tagName: 'div',
+                properties: {},
+                children: [
+                  {
+                    type: 'element',
+                    tagName: 'svg',
+                    properties: {},
+                    children: [
+                      {
+                        type: 'element',
+                        tagName: 'circle',
+                        properties: {},
+                        children: []
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      })
 
       assert.equal(
-        serializeNodeToHtmlString(
-          toDom(
-            {
-              type: 'element',
-              tagName: 'svg',
-              properties: {},
-              children: [
-                {
-                  type: 'element',
-                  tagName: 'foreignObject',
-                  properties: {},
-                  children: [
-                    {
-                      type: 'element',
-                      tagName: 'div',
-                      properties: {},
-                      children: [
-                        {
-                          type: 'element',
-                          tagName: 'svg',
-                          properties: {},
-                          children: [
-                            {
-                              type: 'element',
-                              tagName: 'circle',
-                              properties: {},
-                              children: []
-                            }
-                          ]
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            },
-            {document: instrumentedDocument}
-          )
-        ),
+        serializeNodeToHtmlString(tree),
         '<svg><foreignObject><div><svg><circle/></svg></div></foreignObject></svg>'
       )
 
-      assert.deepEqual(calls, [
+      assert.deepEqual(serializeNodeToNamespaceAndLocalName(tree), [
         [webNamespaces.svg, 'svg'],
         [webNamespaces.svg, 'foreignObject'],
         [webNamespaces.html, 'div'],
@@ -225,39 +219,33 @@ test('toDom', async function (t) {
   await t.test(
     'should create SVG `title` children with HTML namespace',
     async function () {
-      const {calls, document: instrumentedDocument} =
-        createInstrumentedDocument()
+      const tree = toDom({
+        type: 'element',
+        tagName: 'svg',
+        properties: {},
+        children: [
+          {
+            type: 'element',
+            tagName: 'title',
+            properties: {},
+            children: [
+              {
+                type: 'element',
+                tagName: 'span',
+                properties: {},
+                children: []
+              }
+            ]
+          }
+        ]
+      })
 
       assert.equal(
-        serializeNodeToHtmlString(
-          toDom(
-            {
-              type: 'element',
-              tagName: 'svg',
-              properties: {},
-              children: [
-                {
-                  type: 'element',
-                  tagName: 'title',
-                  properties: {},
-                  children: [
-                    {
-                      type: 'element',
-                      tagName: 'span',
-                      properties: {},
-                      children: []
-                    }
-                  ]
-                }
-              ]
-            },
-            {document: instrumentedDocument}
-          )
-        ),
+        serializeNodeToHtmlString(tree),
         '<svg><title><span></span></title></svg>'
       )
 
-      assert.deepEqual(calls, [
+      assert.deepEqual(serializeNodeToNamespaceAndLocalName(tree), [
         [webNamespaces.svg, 'svg'],
         [webNamespaces.svg, 'title'],
         [webNamespaces.html, 'span']
@@ -268,39 +256,33 @@ test('toDom', async function (t) {
   await t.test(
     'should create SVG `desc` children with HTML namespace',
     async function () {
-      const {calls, document: instrumentedDocument} =
-        createInstrumentedDocument()
+      const tree = toDom({
+        type: 'element',
+        tagName: 'svg',
+        properties: {},
+        children: [
+          {
+            type: 'element',
+            tagName: 'desc',
+            properties: {},
+            children: [
+              {
+                type: 'element',
+                tagName: 'span',
+                properties: {},
+                children: []
+              }
+            ]
+          }
+        ]
+      })
 
       assert.equal(
-        serializeNodeToHtmlString(
-          toDom(
-            {
-              type: 'element',
-              tagName: 'svg',
-              properties: {},
-              children: [
-                {
-                  type: 'element',
-                  tagName: 'desc',
-                  properties: {},
-                  children: [
-                    {
-                      type: 'element',
-                      tagName: 'span',
-                      properties: {},
-                      children: []
-                    }
-                  ]
-                }
-              ]
-            },
-            {document: instrumentedDocument}
-          )
-        ),
+        serializeNodeToHtmlString(tree),
         '<svg><desc><span></span></desc></svg>'
       )
 
-      assert.deepEqual(calls, [
+      assert.deepEqual(serializeNodeToNamespaceAndLocalName(tree), [
         [webNamespaces.svg, 'svg'],
         [webNamespaces.svg, 'desc'],
         [webNamespaces.html, 'span']
@@ -311,42 +293,36 @@ test('toDom', async function (t) {
   await t.test(
     'should create MathML `annotation-xml` children with HTML namespace',
     async function () {
-      const {calls, document: instrumentedDocument} =
-        createInstrumentedDocument()
+      const tree = toDom({
+        type: 'element',
+        tagName: 'math',
+        properties: {},
+        children: [
+          {
+            type: 'element',
+            tagName: 'annotation-xml',
+            properties: {encoding: 'text/html'},
+            children: [
+              {
+                type: 'element',
+                tagName: 'paragraph',
+                properties: {},
+                children: []
+              }
+            ]
+          }
+        ]
+      })
 
       assert.equal(
-        serializeNodeToHtmlString(
-          toDom(
-            {
-              type: 'element',
-              tagName: 'math',
-              properties: {},
-              children: [
-                {
-                  type: 'element',
-                  tagName: 'annotation-xml',
-                  properties: {encoding: 'text/html'},
-                  children: [
-                    {
-                      type: 'element',
-                      tagName: 'p',
-                      properties: {},
-                      children: []
-                    }
-                  ]
-                }
-              ]
-            },
-            {document: instrumentedDocument}
-          )
-        ),
-        '<math><annotation-xml encoding="text/html"><p></p></annotation-xml></math>'
+        serializeNodeToHtmlString(tree),
+        '<math><annotation-xml encoding="text/html"><paragraph></paragraph></annotation-xml></math>'
       )
 
-      assert.deepEqual(calls, [
+      assert.deepEqual(serializeNodeToNamespaceAndLocalName(tree), [
         [webNamespaces.mathml, 'math'],
         [webNamespaces.mathml, 'annotation-xml'],
-        [webNamespaces.html, 'p']
+        [webNamespaces.html, 'paragraph']
       ])
     }
   )
@@ -354,42 +330,36 @@ test('toDom', async function (t) {
   await t.test(
     'should create MathML `annotation-xml` children with HTML namespace for `application/xhtml+xml`',
     async function () {
-      const {calls, document: instrumentedDocument} =
-        createInstrumentedDocument()
+      const tree = toDom({
+        type: 'element',
+        tagName: 'math',
+        properties: {},
+        children: [
+          {
+            type: 'element',
+            tagName: 'annotation-xml',
+            properties: {encoding: 'Application/XHTML+XML'},
+            children: [
+              {
+                type: 'element',
+                tagName: 'paragraph',
+                properties: {},
+                children: []
+              }
+            ]
+          }
+        ]
+      })
 
       assert.equal(
-        serializeNodeToHtmlString(
-          toDom(
-            {
-              type: 'element',
-              tagName: 'math',
-              properties: {},
-              children: [
-                {
-                  type: 'element',
-                  tagName: 'annotation-xml',
-                  properties: {encoding: 'Application/XHTML+XML'},
-                  children: [
-                    {
-                      type: 'element',
-                      tagName: 'p',
-                      properties: {},
-                      children: []
-                    }
-                  ]
-                }
-              ]
-            },
-            {document: instrumentedDocument}
-          )
-        ),
-        '<math><annotation-xml encoding="Application/XHTML+XML"><p></p></annotation-xml></math>'
+        serializeNodeToHtmlString(tree),
+        '<math><annotation-xml encoding="Application/XHTML+XML"><paragraph></paragraph></annotation-xml></math>'
       )
 
-      assert.deepEqual(calls, [
+      assert.deepEqual(serializeNodeToNamespaceAndLocalName(tree), [
         [webNamespaces.mathml, 'math'],
         [webNamespaces.mathml, 'annotation-xml'],
-        [webNamespaces.html, 'p']
+        [webNamespaces.html, 'paragraph']
       ])
     }
   )
@@ -775,35 +745,18 @@ function serializeNodeToHtmlString(node) {
 }
 
 /**
- * Create an instrumented document that records `createElementNS` calls.
+ * Collect namespace and local name pairs for an element and descendants.
  *
- * @returns {{calls: Array<[string, string]>, document: Document}}
- *   Call records and instrumented document.
+ * @param {Node} node
+ *   DOM node.
+ * @returns {Array<[string, string]>}
+ *   Namespace and local name pairs in document order.
  */
-function createInstrumentedDocument() {
-  /** @type {Array<[string, string]>} */
-  const calls = []
-  const instrumentedDocument = new Proxy(document, {
-    get(target, key) {
-      if (key === 'createElementNS') {
-        /**
-         * @param {string | null} namespaceURI
-         * @param {string} qualifiedName
-         * @param {string | ElementCreationOptions | undefined} options
-         * @returns {Element}
-         */
-        return function (namespaceURI, qualifiedName, options) {
-          calls.push([String(namespaceURI), qualifiedName])
-          return target.createElementNS(namespaceURI, qualifiedName, options)
-        }
-      }
+function serializeNodeToNamespaceAndLocalName(node) {
+  assert.ok(document.defaultView)
+  assert.ok(node instanceof document.defaultView.Element)
 
-      /** @type {unknown} */
-      const value = Reflect.get(target, key)
-
-      return typeof value === 'function' ? value.bind(target) : value
-    }
+  return [node, ...node.querySelectorAll('*')].map(function (element) {
+    return [String(element.namespaceURI), element.localName]
   })
-
-  return {calls, document: instrumentedDocument}
 }

--- a/test/index.js
+++ b/test/index.js
@@ -164,6 +164,237 @@ test('toDom', async function (t) {
   })
 
   await t.test(
+    'should create SVG `foreignObject` children with HTML namespace',
+    async function () {
+      const {calls, document: instrumentedDocument} =
+        createInstrumentedDocument()
+
+      assert.equal(
+        serializeNodeToHtmlString(
+          toDom(
+            {
+              type: 'element',
+              tagName: 'svg',
+              properties: {},
+              children: [
+                {
+                  type: 'element',
+                  tagName: 'foreignObject',
+                  properties: {},
+                  children: [
+                    {
+                      type: 'element',
+                      tagName: 'div',
+                      properties: {},
+                      children: [
+                        {
+                          type: 'element',
+                          tagName: 'svg',
+                          properties: {},
+                          children: [
+                            {
+                              type: 'element',
+                              tagName: 'circle',
+                              properties: {},
+                              children: []
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {document: instrumentedDocument}
+          )
+        ),
+        '<svg><foreignObject><div><svg><circle/></svg></div></foreignObject></svg>'
+      )
+
+      assert.deepEqual(calls, [
+        [webNamespaces.svg, 'svg'],
+        [webNamespaces.svg, 'foreignObject'],
+        [webNamespaces.html, 'div'],
+        [webNamespaces.svg, 'svg'],
+        [webNamespaces.svg, 'circle']
+      ])
+    }
+  )
+
+  await t.test(
+    'should create SVG `title` children with HTML namespace',
+    async function () {
+      const {calls, document: instrumentedDocument} =
+        createInstrumentedDocument()
+
+      assert.equal(
+        serializeNodeToHtmlString(
+          toDom(
+            {
+              type: 'element',
+              tagName: 'svg',
+              properties: {},
+              children: [
+                {
+                  type: 'element',
+                  tagName: 'title',
+                  properties: {},
+                  children: [
+                    {
+                      type: 'element',
+                      tagName: 'span',
+                      properties: {},
+                      children: []
+                    }
+                  ]
+                }
+              ]
+            },
+            {document: instrumentedDocument}
+          )
+        ),
+        '<svg><title><span></span></title></svg>'
+      )
+
+      assert.deepEqual(calls, [
+        [webNamespaces.svg, 'svg'],
+        [webNamespaces.svg, 'title'],
+        [webNamespaces.html, 'span']
+      ])
+    }
+  )
+
+  await t.test(
+    'should create SVG `desc` children with HTML namespace',
+    async function () {
+      const {calls, document: instrumentedDocument} =
+        createInstrumentedDocument()
+
+      assert.equal(
+        serializeNodeToHtmlString(
+          toDom(
+            {
+              type: 'element',
+              tagName: 'svg',
+              properties: {},
+              children: [
+                {
+                  type: 'element',
+                  tagName: 'desc',
+                  properties: {},
+                  children: [
+                    {
+                      type: 'element',
+                      tagName: 'span',
+                      properties: {},
+                      children: []
+                    }
+                  ]
+                }
+              ]
+            },
+            {document: instrumentedDocument}
+          )
+        ),
+        '<svg><desc><span></span></desc></svg>'
+      )
+
+      assert.deepEqual(calls, [
+        [webNamespaces.svg, 'svg'],
+        [webNamespaces.svg, 'desc'],
+        [webNamespaces.html, 'span']
+      ])
+    }
+  )
+
+  await t.test(
+    'should create MathML `annotation-xml` children with HTML namespace',
+    async function () {
+      const {calls, document: instrumentedDocument} =
+        createInstrumentedDocument()
+
+      assert.equal(
+        serializeNodeToHtmlString(
+          toDom(
+            {
+              type: 'element',
+              tagName: 'math',
+              properties: {},
+              children: [
+                {
+                  type: 'element',
+                  tagName: 'annotation-xml',
+                  properties: {encoding: 'text/html'},
+                  children: [
+                    {
+                      type: 'element',
+                      tagName: 'p',
+                      properties: {},
+                      children: []
+                    }
+                  ]
+                }
+              ]
+            },
+            {document: instrumentedDocument}
+          )
+        ),
+        '<math><annotation-xml encoding="text/html"><p></p></annotation-xml></math>'
+      )
+
+      assert.deepEqual(calls, [
+        [webNamespaces.mathml, 'math'],
+        [webNamespaces.mathml, 'annotation-xml'],
+        [webNamespaces.html, 'p']
+      ])
+    }
+  )
+
+  await t.test(
+    'should create MathML `annotation-xml` children with HTML namespace for `application/xhtml+xml`',
+    async function () {
+      const {calls, document: instrumentedDocument} =
+        createInstrumentedDocument()
+
+      assert.equal(
+        serializeNodeToHtmlString(
+          toDom(
+            {
+              type: 'element',
+              tagName: 'math',
+              properties: {},
+              children: [
+                {
+                  type: 'element',
+                  tagName: 'annotation-xml',
+                  properties: {encoding: 'Application/XHTML+XML'},
+                  children: [
+                    {
+                      type: 'element',
+                      tagName: 'p',
+                      properties: {},
+                      children: []
+                    }
+                  ]
+                }
+              ]
+            },
+            {document: instrumentedDocument}
+          )
+        ),
+        '<math><annotation-xml encoding="Application/XHTML+XML"><p></p></annotation-xml></math>'
+      )
+
+      assert.deepEqual(calls, [
+        [webNamespaces.mathml, 'math'],
+        [webNamespaces.mathml, 'annotation-xml'],
+        [webNamespaces.html, 'p']
+      ])
+    }
+  )
+
+  await t.test(
     'should create an input node with some attributes',
     async function () {
       assert.equal(
@@ -541,4 +772,38 @@ function serializeNodeToHtmlString(node) {
       '$1'
     )
     .replace(/<(mglyph|malignmark|mspace)\/>/g, '<$1></$1>')
+}
+
+/**
+ * Create an instrumented document that records `createElementNS` calls.
+ *
+ * @returns {{calls: Array<[string, string]>, document: Document}}
+ *   Call records and instrumented document.
+ */
+function createInstrumentedDocument() {
+  /** @type {Array<[string, string]>} */
+  const calls = []
+  const instrumentedDocument = new Proxy(document, {
+    get(target, key) {
+      if (key === 'createElementNS') {
+        /**
+         * @param {string | null} namespaceURI
+         * @param {string} qualifiedName
+         * @param {string | ElementCreationOptions | undefined} options
+         * @returns {Element}
+         */
+        return function (namespaceURI, qualifiedName, options) {
+          calls.push([String(namespaceURI), qualifiedName])
+          return target.createElementNS(namespaceURI, qualifiedName, options)
+        }
+      }
+
+      /** @type {unknown} */
+      const value = Reflect.get(target, key)
+
+      return typeof value === 'function' ? value.bind(target) : value
+    }
+  })
+
+  return {calls, document: instrumentedDocument}
 }

--- a/test/index.js
+++ b/test/index.js
@@ -121,6 +121,19 @@ test('toDom', async function (t) {
     )
   })
 
+  await t.test('should create an unknown node in MathML', async function () {
+    assert.equal(
+      serializeNodeToHtmlString(
+        toDom(
+          // @ts-expect-error: check how an unknown node is handled.
+          {type: 'something-else'},
+          {namespace: webNamespaces.mathml}
+        )
+      ),
+      '<mrow/>'
+    )
+  })
+
   await t.test(
     'should create an unknown node (with children)',
     async function () {

--- a/test/index.js
+++ b/test/index.js
@@ -177,6 +177,54 @@ test('toDom', async function (t) {
   })
 
   await t.test(
+    'should create HTML elements with `createElement()` when namespace is omitted',
+    async function () {
+      const tree = toDom(
+        {
+          type: 'root',
+          children: [
+            {
+              type: 'element',
+              tagName: 'dIv',
+              properties: {},
+              children: [{type: 'text', value: 'Hi'}]
+            }
+          ]
+        },
+        {fragment: true}
+      )
+
+      // Infer the use of `createElement()` from the lowercased tag name.
+      assert.equal(serializeNodeToHtmlString(tree), '<div>Hi</div>')
+    }
+  )
+
+  await t.test(
+    'should create HTML elements with `createElementNS()` when namespace is provided',
+    async function () {
+      const tree = toDom(
+        {
+          type: 'root',
+          children: [
+            {
+              type: 'element',
+              tagName: 'dIv',
+              properties: {
+                xmlns: webNamespaces.html
+              },
+              children: [{type: 'text', value: 'Hi'}]
+            }
+          ]
+        },
+        {fragment: true}
+      )
+
+      // Infer the use of `createElementNS()` from the non-lowercased tag name
+      assert.equal(serializeNodeToHtmlString(tree), '<dIv>Hi</dIv>')
+    }
+  )
+
+  await t.test(
     'should create SVG `foreignObject` children with HTML namespace',
     async function () {
       const tree = toDom(

--- a/test/index.js
+++ b/test/index.js
@@ -166,40 +166,9 @@ test('toDom', async function (t) {
   await t.test(
     'should create SVG `foreignObject` children with HTML namespace',
     async function () {
-      const tree = toDom({
-        type: 'element',
-        tagName: 'svg',
-        properties: {},
-        children: [
-          {
-            type: 'element',
-            tagName: 'foreignObject',
-            properties: {},
-            children: [
-              {
-                type: 'element',
-                tagName: 'div',
-                properties: {},
-                children: [
-                  {
-                    type: 'element',
-                    tagName: 'svg',
-                    properties: {},
-                    children: [
-                      {
-                        type: 'element',
-                        tagName: 'circle',
-                        properties: {},
-                        children: []
-                      }
-                    ]
-                  }
-                ]
-              }
-            ]
-          }
-        ]
-      })
+      const tree = toDom(
+        s('svg', s('foreignObject', h('div', s('svg', s('circle')))))
+      )
 
       assert.equal(
         serializeNodeToHtmlString(tree),
@@ -219,26 +188,7 @@ test('toDom', async function (t) {
   await t.test(
     'should create SVG `title` children with HTML namespace',
     async function () {
-      const tree = toDom({
-        type: 'element',
-        tagName: 'svg',
-        properties: {},
-        children: [
-          {
-            type: 'element',
-            tagName: 'title',
-            properties: {},
-            children: [
-              {
-                type: 'element',
-                tagName: 'span',
-                properties: {},
-                children: []
-              }
-            ]
-          }
-        ]
-      })
+      const tree = toDom(s('svg', s('title', h('span'))))
 
       assert.equal(
         serializeNodeToHtmlString(tree),
@@ -256,26 +206,7 @@ test('toDom', async function (t) {
   await t.test(
     'should create SVG `desc` children with HTML namespace',
     async function () {
-      const tree = toDom({
-        type: 'element',
-        tagName: 'svg',
-        properties: {},
-        children: [
-          {
-            type: 'element',
-            tagName: 'desc',
-            properties: {},
-            children: [
-              {
-                type: 'element',
-                tagName: 'span',
-                properties: {},
-                children: []
-              }
-            ]
-          }
-        ]
-      })
+      const tree = toDom(s('svg', s('desc', h('span'))))
 
       assert.equal(
         serializeNodeToHtmlString(tree),
@@ -293,26 +224,9 @@ test('toDom', async function (t) {
   await t.test(
     'should create MathML `annotation-xml` children with HTML namespace',
     async function () {
-      const tree = toDom({
-        type: 'element',
-        tagName: 'math',
-        properties: {},
-        children: [
-          {
-            type: 'element',
-            tagName: 'annotation-xml',
-            properties: {encoding: 'text/html'},
-            children: [
-              {
-                type: 'element',
-                tagName: 'paragraph',
-                properties: {},
-                children: []
-              }
-            ]
-          }
-        ]
-      })
+      const tree = toDom(
+        h('math', h('annotation-xml', {encoding: 'text/html'}, h('paragraph')))
+      )
 
       assert.equal(
         serializeNodeToHtmlString(tree),
@@ -330,26 +244,16 @@ test('toDom', async function (t) {
   await t.test(
     'should create MathML `annotation-xml` children with HTML namespace for `application/xhtml+xml`',
     async function () {
-      const tree = toDom({
-        type: 'element',
-        tagName: 'math',
-        properties: {},
-        children: [
-          {
-            type: 'element',
-            tagName: 'annotation-xml',
-            properties: {encoding: 'Application/XHTML+XML'},
-            children: [
-              {
-                type: 'element',
-                tagName: 'paragraph',
-                properties: {},
-                children: []
-              }
-            ]
-          }
-        ]
-      })
+      const tree = toDom(
+        h(
+          'math',
+          h(
+            'annotation-xml',
+            {encoding: 'Application/XHTML+XML'},
+            h('paragraph')
+          )
+        )
+      )
 
       assert.equal(
         serializeNodeToHtmlString(tree),


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]).
  Leave the comments as they are: they do not show on GitHub.

  Please try to limit the scope,
  provide a general description of the changes,
  and remember it’s up to you to convince us to land it.

  We are excited about pull requests.
  Thank you!
-->

### Initial checklist

* [x] I read the support docs <!-- https://github.com/syntax-tree/.github/blob/main/support.md -->
* [x] I read the contributing guide <!-- https://github.com/syntax-tree/.github/blob/main/contributing.md -->
* [x] I agree to follow the code of conduct <!-- https://github.com/syntax-tree/.github/blob/main/code-of-conduct.md -->
* [x] I searched issues and discussions and couldn’t find anything or linked relevant results below <!-- https://github.com/search?q=user%3Asyntax-tree&type=issues and https://github.com/orgs/syntax-tree/discussions -->
* [x] I made sure the docs are up to date
* [x] I included tests (or that’s not needed)

### Description of changes

This pull request is intended to align the namespace-switching logic to the [HTML Living Standard § 13.2.6](https://html.spec.whatwg.org/multipage/parsing.html#html-integration-point). I needed this done because I was running into a problem when child elements of `foreignObject` were being created in the SVG namespace instead of the HTML namespace. Since I needed this fixed for my own project whether it gets accepted to the official release or not, I wrote the code without opening an issue. Now that I've got it working, I'm sharing what I've got so far. I hope that's okay. 

In particular, this changes namespace selection in the following cases:

- **SVG:** In the SVG namespace, the HTML namespace is selected for child elements of `<foreignObject>`, `<desc>`, and `<title>`.

- **MathML:** In the HTML namespace, the MathML namespace is selected for `<math>` elements. In the MathML namespace, the HTML namespace is selected for `<annotation-xml>` elements that have an `encoding` attribute that matches either `text/html` or `application/xhtml+xml`. The standard calls for a text integration point on `<mi>`, `<mo>`, `<mn>`, `<ms>`, and `<mtext>`, but I couldn't confidently say if that means the namespace should switch to HTML, so I didn't add special handling for those.

- **Explicit Overrides:** The xmlns property values on individual elements override the implicitly inherited namespace, not just the root element.

Two existing tests would fail because of this work, but I tried to follow the convention that was established in the `serializeNodeToHtmlString()` helper function by adding the MathML namespace to the string replacement chain. Downstream code that is closely coupled to the previous namespace selection behavior could break, so I would consider this to be a breaking change. I also added a few new tests to assert the intended namespaces rather than modifying existing tests to do the same. Maybe the tests could be consolidated, but I wanted to leave the existing tests as-is to improve confidence in the impact of this pull request. 

<!--do not edit: pr-->
